### PR TITLE
Add dictee — local voice dictation with KDE Plasma integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Tip: An overview of the most used KDE community apps are listed on the [official
 
 - [Android File Transfer](https://whoozle.github.io/android-file-transfer-linux/) - Reliable MTP client with minimalistic UI.
 - [Ark](https://apps.kde.org/ark/) - Archiving Tool 📌.
+- [dictee](https://github.com/rcspam/dictee) - Push-to-talk voice dictation with GTK3 config UI, tray icon, and KDE Plasma shortcut integration. 100% local, 25+ languages.
 - [fancontrol-gui](https://github.com/Maldela/fancontrol-gui) - GUI for fancontrol which is part of lm_sensors.
 - [KDE Wallet Manager](https://invent.kde.org/utilities/kwalletmanager/) - Manage the passwords on KDE systems. The KDE wallet subsystem allows access and password management of every application that integrates with the KDE wallet 📌.
 - [KeePassXC](https://keepassxc.org/) - Cross-platform community-driven port of Keepass password manager.


### PR DESCRIPTION
## Summary
- Adds [dictee](https://github.com/rcspam/dictee), a push-to-talk voice dictation tool with native KDE Plasma integration
- Automatic keyboard shortcut registration in Plasma
- Tray icon adapts to Plasma themes (light/dark)
- 100% local transcription (NVIDIA Parakeet via ONNX Runtime), 25+ languages
- GPL-3.0 license