### PR TITLE
docs: update dictee description for v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Tip: An overview of the most used KDE community apps are listed on the [official
 
 - [Android File Transfer](https://whoozle.github.io/android-file-transfer-linux/) - Reliable MTP client with minimalistic UI.
 - [Ark](https://apps.kde.org/ark/) - Archiving Tool 📌.
-- [dictee](https://github.com/rcspam/dictee) - Push-to-talk voice dictation with GTK3 config UI, tray icon, and KDE Plasma shortcut integration. 100% local, 25+ languages.
+- [dictee](https://github.com/rcspam/dictee) - Push-to-talk voice dictation with KDE Plasma 6 plasmoid, PyQt6 setup wizard, and tray icon. 4 ASR backends (Parakeet, Vosk, Whisper, Canary), post-processing pipeline, translation. 100% local, 25+ languages.
 - [fancontrol-gui](https://github.com/Maldela/fancontrol-gui) - GUI for fancontrol which is part of lm_sensors.
 - [KDE Wallet Manager](https://invent.kde.org/utilities/kwalletmanager/) - Manage the passwords on KDE systems. The KDE wallet subsystem allows access and password management of every application that integrates with the KDE wallet 📌.
 - [KeePassXC](https://keepassxc.org/) - Cross-platform community-driven port of Keepass password manager.


### PR DESCRIPTION
Update the description for [dictee](https://github.com/rcspam/dictee) to reflect v1.2.0 changes:

- **Before:** "Push-to-talk voice dictation with GTK3 config UI, tray icon, and KDE Plasma shortcut integration. 100% local, 25+ languages."
- **After:** "Push-to-talk voice dictation with KDE Plasma 6 plasmoid, PyQt6 setup wizard, and tray icon. 4 ASR backends (Parakeet, Vosk, Whisper, Canary), post-processing pipeline, translation. 100% local, 25+ languages."

Key changes since the original listing:
- GTK3 config UI replaced by PyQt6 setup wizard with 6-step first-run flow
- KDE Plasma 6 plasmoid with 5 animation styles and real-time audio visualization
- 4 ASR backends instead of just Parakeet (added Vosk, faster-whisper, Canary-1B)
- Full post-processing pipeline (regex rules, dictionary, continuation, elisions, number conversion, LLM correction)
- Translation support (Google, Bing, LibreTranslate, Ollama)